### PR TITLE
Changing default protobuf size limit

### DIFF
--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -622,7 +622,7 @@ class LIBPROTOBUF_EXPORT CodedInputStream {
   // Return the size of the buffer.
   int BufferSize() const;
 
-  static const int kDefaultTotalBytesLimit = 64 << 20;  // 64MB
+  static const int kDefaultTotalBytesLimit = 512 << 20;  // 512MB
 
   static const int kDefaultTotalBytesWarningThreshold = 32 << 20;  // 32MB
 


### PR DESCRIPTION
Increasing binary size limit to 512 MB